### PR TITLE
Align frontend theme and header layout with Figma

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,37 @@ cd backend
 # or simply "mvn spring-boot:run"
 ```
 The database entity structure/tables will be generated automatically upon the first application start via Hibernate (`ddl-auto=update`).
+
+Core frontend scaffold:
+
+- `src/app/page-registry.ts` is the single route catalog for pages and subpages.
+- `src/app/AppShell.tsx` provides the shared app bar, role switcher, and page navigation.
+- `src/components/AppBreadcrumbs.tsx` renders breadcrumbs automatically from the route catalog.
+- `src/components/PageTemplate.tsx` is the shared page layout wrapper.
+- `src/components/PagePlaceholder.tsx` is the default stub to replace with real page content.
+- `src/features/session/RoleSessionContext.tsx` holds the temporary active role used before real auth exists.
+
+How to add a new page:
+
+1. Create the page component.
+2. Register its route metadata in `src/app/page-registry.ts`.
+3. Attach the component to that route entry when it is ready.
+
+Once a page is registered, the navigation shell and breadcrumbs can use it consistently.
+
+Example:
+
+```ts
+{
+  id: 'customer-events',
+  role: 'customer',
+  path: '/customer/events',
+  title: 'Event Catalog',
+  navLabel: 'Events',
+  description: '...',
+  summary: '...',
+  outcomes: ['...'],
+  icon: EventRoundedIcon,
+  component: CustomerEventsPage,
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,39 @@
+# Ticket Platform - Technical Report
+
+## 1. System Structure and Assigned Technologies
+A **3-tier multi-layer architectural style** was chosen to implement the project. The system is divided into the following layers:
+1. **Presentation Tier**: Designed as a Single Page Application (SPA) running in the browser workspace using **React.js** and Vite. It communicates with the server via REST APIs. The application is entirely stateless on the backend side, therefore satisfying sessionless state rules.
+2. **Business Logic Tier**: Runs on the server side using **Java** and **Spring Boot**. This tier contains `@Service` components that perform decision-making, process logic transactions, and run pricing algorithms. AOP Interceptors are configured exclusively in this layer for business logging.
+3. **Data Access Tier**: Implemented using **Spring Data JPA** (powered by Hibernate ORM) and a **PostgreSQL** relational database. This tier manages data abstraction by avoiding manual SQL queries (preventing SQL injections via internal Prepared Statements) and provides concurrent editing protection via JPA Optimistic Locking.
+
+## 2. Implementation of Qualitative Requirements in Source Code
+
+| Requirement | Technological Solution | Project Example (Class & Explanation) |
+| :--- | :--- | :--- |
+| **Concurrency** | State is not saved in any backend session. HTTP requests are completely "stateless". | `frontend/` React application – user works asynchronously without session locks over the REST boundaries. |
+| **Security (SQL inject)** | Secure queries via JPA "Prepared Statements" are utilized automatically in data operations. | `backend/src/main/java/com/ticketplatform/backend/repository/EventRepository.java` (inherits JpaRepository for automatic query shielding). |
+| **Data Access** | Short transactions bound to single HTTP request scopes are managed via ORM. No logic is stalled pending UI entry. | `backend/src/main/java/com/ticketplatform/backend/service/EventService.java` utilizes the `@Transactional` method boundaries. |
+| **Data consistency (Locking)** | JPA `@Version` annotation enforces conflict rejection (throwing `ObjectOptimisticLockingFailureException`). | `backend/src/main/java/com/ticketplatform/backend/model/Event.java` relies on an integer `@Version` field tracking conflicts. |
+| **Memory management** | `Singleton scope` is strictly upheld for business logic, reducing the RAM footprint by avoiding session scoping. | `backend/src/main/java/com/ticketplatform/backend/service/EventService.java` naturally binds to Spring's default singleton context. |
+| **Interceptors** | Spring AOP (`@Aspect`, `@Before`) logs all Service method invocations remotely without invasively editing primary classes. | `backend/src/main/java/com/ticketplatform/backend/aspect/LoggingAspect.java` executes execution intercepts across the `com.ticketplatform.backend.service.*` package. |
+| **Extensibility** | “Strategy” design pattern implemented for calculating ticket prices based on flexible roles or periods. | Interface: `backend/src/main/java/com/ticketplatform/backend/service/strategy/TicketPriceStrategy.java` and implementation `StandardTicketPriceStrategy.java` |
+
+---
+
+### How to run the project locally?
+
+**Starting the Frontend:**
 ```bash
 cd frontend
-npm run build
+npm install
+npm run dev
 ```
+
+**Starting the Backend (& Database setup):**
+Ensure that a local instance of PostgreSQL is running with an empty database named `ticketplatform` (`username: postgres, password: root`).
+```bash
+cd backend
+./mvnw spring-boot:run
+# or simply "mvn spring-boot:run"
+```
+The database entity structure/tables will be generated automatically upon the first application start via Hibernate (`ddl-auto=update`).

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,13 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### Mac ###
+.DS_Store

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.4</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+  <groupId>com.ticketplatform</groupId>
+  <artifactId>backend</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>backend</name>
+  <description>Ticket Platform Backend for University Project</description>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+  <dependencies>
+    <!-- Web (REST, DispatcherServlet) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <!-- Data Access (JPA, Hibernate, Transactional, Optimistic Locking) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <!-- Database Driver -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- AOP for Interceptors/Logging -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <!-- Lombok (to reduce boilerplate getters/setters) -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/backend/src/main/java/com/ticketplatform/backend/BackendApplication.java
+++ b/backend/src/main/java/com/ticketplatform/backend/BackendApplication.java
@@ -1,0 +1,11 @@
+package com.ticketplatform.backend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/ticketplatform/backend/aspect/LoggingAspect.java
+++ b/backend/src/main/java/com/ticketplatform/backend/aspect/LoggingAspect.java
@@ -1,0 +1,31 @@
+package com.ticketplatform.backend.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Aspect
+@Component
+public class LoggingAspect {
+
+    // REQUIREMENT: Cross-cutting functionality/Interceptors
+    // Logging all business logic (Service class) method invocations
+    // without modifying the Service classes themselves. Changing logging logic
+    // does not require recompiling or modifying the observed code.
+
+    @Before("execution(* com.ticketplatform.backend.service.*.*(..))")
+    public void logBeforeBusinessMethod(JoinPoint joinPoint) {
+        String className = joinPoint.getTarget().getClass().getSimpleName();
+        String methodName = joinPoint.getSignature().getName();
+        LocalDateTime time = LocalDateTime.now();
+        
+        // In practice, we would use SecurityContext to retrieve the logged-in user
+        String user = "SYSTEM_OR_LOGGED_IN_USER"; 
+
+        System.out.printf("[%s] Executing '%s.%s' on behalf of user: %s%n",
+                time, className, methodName, user);
+    }
+}

--- a/backend/src/main/java/com/ticketplatform/backend/controller/EventController.java
+++ b/backend/src/main/java/com/ticketplatform/backend/controller/EventController.java
@@ -1,0 +1,34 @@
+package com.ticketplatform.backend.controller;
+
+import com.ticketplatform.backend.model.Event;
+import com.ticketplatform.backend.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/events")
+public class EventController {
+
+    private final EventService eventService;
+
+    public EventController(EventService eventService) {
+        this.eventService = eventService;
+    }
+
+    // REQUIREMENT: 3-tier presentation layer
+    // React will call these REST API endpoints. A transaction is started during the HTTP request.
+
+    @PostMapping
+    public ResponseEntity<Event> createEvent(@RequestBody Event event) {
+        Event created = eventService.createEvent(event);
+        return ResponseEntity.ok(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Event> updateEvent(@PathVariable String id, @RequestBody Event event) {
+        // Throws ObjectOptimisticLockingFailureException in case
+        // versions no longer match, and GlobalExceptionHandler would return HTTP 409 (Conflict).
+        return ResponseEntity.ok(eventService.updateEvent(event));
+    }
+}

--- a/backend/src/main/java/com/ticketplatform/backend/model/Event.java
+++ b/backend/src/main/java/com/ticketplatform/backend/model/Event.java
@@ -1,0 +1,40 @@
+package com.ticketplatform.backend.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "events")
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDateTime date;
+
+    @Column(nullable = false)
+    private String location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organizer_id", nullable = false)
+    private User organizer;
+
+    private Integer totalTickets;
+
+    // REQUIREMENT: Data consistency; Optimistic locking
+    // If two organizers attempt to edit an event simultaneously,
+    // the system will throw an ObjectOptimisticLockingFailureException.
+    @Version
+    private Integer version;
+}

--- a/backend/src/main/java/com/ticketplatform/backend/model/Ticket.java
+++ b/backend/src/main/java/com/ticketplatform/backend/model/Ticket.java
@@ -1,0 +1,32 @@
+package com.ticketplatform.backend.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "tickets")
+public class Ticket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attendee_id", nullable = false)
+    private User attendee;
+
+    @Column(unique = true, nullable = false)
+    private String qrCode;
+
+    @Column(nullable = false)
+    private String status; // E.g., "VALID", "USED"
+
+    @Version
+    private Integer version;
+}

--- a/backend/src/main/java/com/ticketplatform/backend/model/User.java
+++ b/backend/src/main/java/com/ticketplatform/backend/model/User.java
@@ -1,0 +1,29 @@
+package com.ticketplatform.backend.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "users")
+public class User {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @Column(nullable = false)
+    private String role; // "ORGANIZER" or "ATTENDEE"
+
+    // REQUIREMENT: Data consistency; Optimistic locking
+    // JPA Optimistic locking technique - version column preventing concurrent conflicting updates.
+    @Version
+    private Integer version;
+}

--- a/backend/src/main/java/com/ticketplatform/backend/repository/EventRepository.java
+++ b/backend/src/main/java/com/ticketplatform/backend/repository/EventRepository.java
@@ -1,0 +1,17 @@
+package com.ticketplatform.backend.repository;
+
+import com.ticketplatform.backend.model.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+// REQUIREMENT: Security (SQL injection prevention)
+// Spring Data JPA (JpaRepository) automatically uses secure 'Prepared Statements'
+// for data retrieval, thus protecting the system from SQL injections.
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, UUID> {
+    // Additional methods can be written here, e.g.:
+    // List<Event> findByTitleContainingIgnoreCase(String title);
+}

--- a/backend/src/main/java/com/ticketplatform/backend/service/EventService.java
+++ b/backend/src/main/java/com/ticketplatform/backend/service/EventService.java
@@ -1,0 +1,34 @@
+package com.ticketplatform.backend.service;
+
+import com.ticketplatform.backend.model.Event;
+import com.ticketplatform.backend.repository.EventRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// REQUIREMENT: Data Access / Transactions
+// The transaction spans only the execution time of this method, and starts/ends
+// within the boundaries of a single HTTP request. It does not last longer than the user's "think" time.
+// REQUIREMENT: Memory management
+// This is the default Singleton Scope component, which saves RAM (not created separately for each user).
+
+@Service
+public class EventService {
+
+    private final EventRepository eventRepository;
+
+    public EventService(EventRepository eventRepository) {
+        this.eventRepository = eventRepository;
+    }
+
+    @Transactional
+    public Event createEvent(Event event) {
+        return eventRepository.save(event);
+    }
+
+    @Transactional
+    public Event updateEvent(Event event) {
+        // When updating an event, JPA Optimistic Locking will automatically
+        // check the @Version field defined in the 'Event' class.
+        return eventRepository.save(event);
+    }
+}

--- a/backend/src/main/java/com/ticketplatform/backend/service/strategy/StandardTicketPriceStrategy.java
+++ b/backend/src/main/java/com/ticketplatform/backend/service/strategy/StandardTicketPriceStrategy.java
@@ -1,0 +1,16 @@
+package com.ticketplatform.backend.service.strategy;
+
+import com.ticketplatform.backend.model.Event;
+import com.ticketplatform.backend.model.User;
+import org.springframework.stereotype.Component;
+
+@Component("standardPriceStrategy")
+public class StandardTicketPriceStrategy implements TicketPriceStrategy {
+
+    @Override
+    public double calculatePrice(Event event, User attendee) {
+        // In the future, role-based discounts can be implemented here.
+        // For now, a standard static price is returned for illustration purposes.
+        return 20.00;
+    }
+}

--- a/backend/src/main/java/com/ticketplatform/backend/service/strategy/TicketPriceStrategy.java
+++ b/backend/src/main/java/com/ticketplatform/backend/service/strategy/TicketPriceStrategy.java
@@ -1,0 +1,12 @@
+package com.ticketplatform.backend.service.strategy;
+
+import com.ticketplatform.backend.model.Event;
+import com.ticketplatform.backend.model.User;
+
+// REQUIREMENT: Extensibility/Glass-box extensibility
+// By changing this strategy to another implementation, we can modify the algorithm
+// without recompiling the main code that invokes the price calculation.
+
+public interface TicketPriceStrategy {
+    double calculatePrice(Event event, User attendee);
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+# Database connection settings
+spring.datasource.url=jdbc:postgresql://localhost:5432/ticketplatform
+spring.datasource.username=postgres
+spring.datasource.password=root
+
+# Hibernate configuration
+# Automatically creates or updates tables based on our Entity classes
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# AOP for logging
+spring.aop.proxy-target-class=true
+
+# Server port
+server.port=8080

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TicketPlatform Frontend</title>
   </head>

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -2,13 +2,12 @@ import { startTransition } from 'react';
 import {
   AppBar,
   Box,
+  Button,
   Container,
   FormControl,
-  InputLabel,
   MenuItem,
   Select,
-  Tab,
-  Tabs,
+  Stack,
   Toolbar,
   Typography,
 } from '@mui/material';
@@ -34,19 +33,93 @@ function AppShell() {
   }
 
   return (
-    <Box sx={{ minHeight: '100vh' }}>
-      <AppBar position="sticky" color="transparent" elevation={0}>
+    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', color: 'text.primary' }}>
+      <AppBar position="sticky" color="primary" elevation={0}>
         <Container maxWidth="xl">
-          <Toolbar disableGutters sx={{ gap: 2, py: 1.5, flexWrap: 'wrap' }}>
-            <Typography variant="h6">TicketPlatform</Typography>
+          <Toolbar
+            disableGutters
+            sx={{
+              minHeight: 88,
+              py: 1.5,
+              gap: 3,
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <Typography
+              variant="h5"
+              sx={{ color: 'common.white', fontWeight: 500, letterSpacing: '-0.02em' }}
+            >
+              TicketPlatform
+            </Typography>
 
-            <Box sx={{ flexGrow: 1 }} />
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                justifyContent: 'flex-end',
+                marginLeft: 'auto',
+              }}
+            >
+              {navPages.map((page) => {
+                const isActive = page.path === activeNavPage?.path;
 
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', sm: 220 } }}>
-              <InputLabel id="role-select-label">Role</InputLabel>
+                return (
+                  <Button
+                    key={page.path}
+                    component={RouterLink}
+                    to={page.path}
+                    disableElevation
+                    sx={{
+                      px: 2.25,
+                      py: 1,
+                      minWidth: 'auto',
+                      borderRadius: '12px',
+                      color: 'common.white',
+                      backgroundColor: isActive ? 'primary.main' : 'transparent',
+                      '&:hover': {
+                        backgroundColor: isActive ? 'primary.main' : 'primary.dark',
+                      },
+                    }}
+                  >
+                    {page.navLabel}
+                  </Button>
+                );
+              })}
+
+              <FormControl
+                size="small"
+                sx={{
+                  minWidth: 164,
+                  '& .MuiOutlinedInput-root': {
+                    borderRadius: '999px',
+                    backgroundColor: 'secondary.main',
+                    color: 'common.white',
+                  },
+                  '& .MuiOutlinedInput-notchedOutline': {
+                    border: 'none',
+                  },
+                  '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
+                    border: 'none',
+                  },
+                  '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                    border: 'none',
+                  },
+                  '& .MuiSelect-icon': {
+                    color: 'common.white',
+                  },
+                  '& .MuiSelect-select': {
+                    py: 1,
+                    pr: 4.5,
+                    pl: 2,
+                    color: 'common.white',
+                  },
+                }}
+              >
               <Select
-                labelId="role-select-label"
-                label="Role"
                 value={role}
                 onChange={(event) => handleRoleChange(event.target.value as UserRole)}
               >
@@ -56,28 +129,9 @@ function AppShell() {
                   </MenuItem>
                 ))}
               </Select>
-            </FormControl>
+              </FormControl>
+            </Stack>
           </Toolbar>
-        </Container>
-
-        <Container maxWidth="xl">
-          <Tabs
-            value={activeNavPage?.path ?? false}
-            variant="scrollable"
-            scrollButtons="auto"
-            allowScrollButtonsMobile
-            sx={{ minHeight: 56 }}
-          >
-            {navPages.map((page) => (
-              <Tab
-                key={page.path}
-                value={page.path}
-                component={RouterLink}
-                to={page.path}
-                label={page.navLabel}
-              />
-            ))}
-          </Tabs>
         </Container>
       </AppBar>
 

--- a/frontend/src/app/theme.ts
+++ b/frontend/src/app/theme.ts
@@ -1,43 +1,79 @@
 import { createTheme } from '@mui/material/styles';
 
+const figmaPalette = {
+  inkBlack: '#061E23',
+  stormyTeal: '#336970',
+  darkCyan: '#24948E',
+  lightCyan: '#DAF9FB',
+  pumpkinSpice: '#F27618',
+  black: '#000000',
+  white: '#FFFFFF',
+  brightFern: '#35B109',
+  brickEmber: '#CF0000',
+  schoolBusYellow: '#FFC800',
+} as const;
+
 export const appTheme = createTheme({
   palette: {
     mode: 'light',
     primary: {
-      main: '#155eef',
-      dark: '#0040c1',
-      light: '#5b8cff',
+      main: figmaPalette.darkCyan,
+      dark: figmaPalette.stormyTeal,
+      light: figmaPalette.lightCyan,
+      contrastText: figmaPalette.white,
     },
     secondary: {
-      main: '#0f766e',
+      main: figmaPalette.pumpkinSpice,
+      contrastText: figmaPalette.white,
+    },
+    success: {
+      main: figmaPalette.brightFern,
+      contrastText: figmaPalette.white,
+    },
+    error: {
+      main: figmaPalette.brickEmber,
+      contrastText: figmaPalette.white,
+    },
+    warning: {
+      main: figmaPalette.schoolBusYellow,
+      contrastText: figmaPalette.black,
     },
     background: {
-      default: '#f4f7fb',
-      paper: '#ffffff',
+      default: figmaPalette.lightCyan,
+      paper: figmaPalette.white,
     },
     text: {
-      primary: '#122033',
-      secondary: '#516076',
+      primary: figmaPalette.black,
+      secondary: figmaPalette.inkBlack,
+      disabled: figmaPalette.stormyTeal,
     },
+    divider: figmaPalette.lightCyan,
   },
   shape: {
     borderRadius: 18,
   },
   typography: {
-    fontFamily: '"IBM Plex Sans", "Segoe UI", sans-serif',
+    fontFamily: '"Poppins", "Segoe UI", sans-serif',
+    fontWeightLight: 400,
+    fontWeightRegular: 400,
+    fontWeightMedium: 500,
+    fontWeightBold: 500,
     h3: {
-      fontWeight: 700,
+      fontWeight: 500,
       letterSpacing: '-0.03em',
     },
     h4: {
-      fontWeight: 700,
+      fontWeight: 500,
       letterSpacing: '-0.02em',
     },
     h5: {
-      fontWeight: 700,
+      fontWeight: 500,
+    },
+    h6: {
+      fontWeight: 500,
     },
     button: {
-      fontWeight: 600,
+      fontWeight: 500,
       textTransform: 'none',
     },
   },
@@ -45,7 +81,8 @@ export const appTheme = createTheme({
     MuiCssBaseline: {
       styleOverrides: {
         body: {
-          background: '#f4f7fb',
+          background: figmaPalette.lightCyan,
+          color: figmaPalette.black,
         },
       },
     },
@@ -53,8 +90,14 @@ export const appTheme = createTheme({
       styleOverrides: {
         root: {
           backgroundImage: 'none',
-          backgroundColor: 'rgba(255, 255, 255, 0.92)',
-          borderBottom: '1px solid rgba(18, 32, 51, 0.08)',
+          backgroundColor: figmaPalette.inkBlack,
+          color: figmaPalette.white,
+          boxShadow: 'none',
+        },
+        colorPrimary: {
+          backgroundImage: 'none',
+          backgroundColor: figmaPalette.inkBlack,
+          color: figmaPalette.white,
         },
       },
     },
@@ -62,6 +105,8 @@ export const appTheme = createTheme({
       styleOverrides: {
         root: {
           backgroundImage: 'none',
+          backgroundColor: figmaPalette.white,
+          color: figmaPalette.black,
           borderRadius: 24,
         },
       },
@@ -70,14 +115,15 @@ export const appTheme = createTheme({
       styleOverrides: {
         root: {
           backgroundImage: 'none',
+          backgroundColor: figmaPalette.white,
+          color: figmaPalette.black,
         },
       },
     },
-    MuiTab: {
+    MuiLink: {
       styleOverrides: {
         root: {
-          minHeight: 56,
-          paddingInline: 18,
+          color: 'inherit',
         },
       },
     },

--- a/frontend/src/components/AppBreadcrumbs.tsx
+++ b/frontend/src/components/AppBreadcrumbs.tsx
@@ -22,7 +22,7 @@ export function AppBreadcrumbs() {
 
         if (isLastPage) {
           return (
-            <Typography key={page.path} color="text.primary" sx={{ fontWeight: 600 }}>
+            <Typography key={page.path} color="text.primary" sx={{ fontWeight: 500 }}>
               {page.title}
             </Typography>
           );

--- a/frontend/src/components/PagePlaceholder.tsx
+++ b/frontend/src/components/PagePlaceholder.tsx
@@ -13,11 +13,10 @@ export function PagePlaceholder({ page }: PagePlaceholderProps) {
   return (
     <PageTemplate page={page}>
       <Paper
-        variant="outlined"
         sx={{
           p: 3,
-          borderRadius: 4,
-          borderColor: 'rgba(18, 32, 51, 0.08)',
+          borderRadius: '24px',
+          backgroundColor: 'background.paper',
         }}
       >
         <Typography color="text.secondary">Page not implemented yet.</Typography>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,5 +1,15 @@
 :root {
   color-scheme: light;
+  --color-ink-black: #061e23;
+  --color-stormy-teal: #336970;
+  --color-dark-cyan: #24948e;
+  --color-light-cyan: #daf9fb;
+  --color-pumpkin-spice: #f27618;
+  --color-text-black: #000000;
+  --color-text-white: #ffffff;
+  --color-text-success: #35b109;
+  --color-text-error: #cf0000;
+  --color-text-warning: #ffc800;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -15,6 +25,9 @@ body,
 body {
   margin: 0;
   min-width: 320px;
+  font-family: 'Poppins', 'Segoe UI', sans-serif;
+  background-color: var(--color-light-cyan);
+  color: var(--color-text-black);
 }
 
 a {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "TicketPlatform",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Updates the frontend to use the Figma color palette and Poppins typography, removes extra borders, and rebuilds the header into a single-row layout with right-aligned navigation and role selector. 


Rebased on backend so should be ok to merge.