### PR TITLE
feat: add customer purchased tickets flow

### DIFF
--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -1,19 +1,19 @@
-import { startTransition } from 'react';
+import { startTransition, useEffect, useState, type MouseEvent } from 'react';
 import {
   AppBar,
   Box,
   Button,
   Container,
-  FormControl,
+  IconButton,
+  Menu,
   MenuItem,
-  Select,
   Stack,
   Toolbar,
   Typography,
 } from '@mui/material';
+import PersonOutlineOutlined from '@mui/icons-material/PersonOutlineOutlined';
 import { Link as RouterLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { AppBreadcrumbs } from '../components/AppBreadcrumbs';
-import { getActiveNavPage, getNavPagesForRole } from './page-registry';
+import { getNavPagesForRole } from './page-registry';
 import { roleHomePaths, roleLabels, roles, type UserRole } from './roles';
 import { useRoleSession } from '../features/session/RoleSessionContext';
 
@@ -21,10 +21,24 @@ function AppShell() {
   const location = useLocation();
   const navigate = useNavigate();
   const { role, setRole } = useRoleSession();
+  const [roleMenuAnchor, setRoleMenuAnchor] = useState<HTMLElement | null>(null);
   const navPages = getNavPagesForRole(role);
-  const activeNavPage = getActiveNavPage(role, location.pathname);
+  const isRoleMenuOpen = Boolean(roleMenuAnchor);
+
+  useEffect(() => {
+    window.scrollTo({ left: 0, top: 0 });
+  }, [location.pathname]);
+
+  function handleRoleMenuOpen(event: MouseEvent<HTMLElement>) {
+    setRoleMenuAnchor(event.currentTarget);
+  }
+
+  function handleRoleMenuClose() {
+    setRoleMenuAnchor(null);
+  }
 
   function handleRoleChange(nextRole: UserRole) {
+    setRoleMenuAnchor(null);
     setRole(nextRole);
 
     startTransition(() => {
@@ -35,12 +49,11 @@ function AppShell() {
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', color: 'text.primary' }}>
       <AppBar position="sticky" color="primary" elevation={0}>
-        <Container maxWidth="xl">
+        <Container maxWidth={false} sx={{ px: { xs: 3, md: 8, lg: 12.5 } }}>
           <Toolbar
             disableGutters
             sx={{
-              minHeight: 88,
-              py: 1.5,
+              minHeight: { xs: 96, md: 140 },
               gap: 3,
               justifyContent: 'space-between',
               alignItems: 'center',
@@ -48,15 +61,23 @@ function AppShell() {
             }}
           >
             <Typography
-              variant="h5"
-              sx={{ color: 'common.white', fontWeight: 500, letterSpacing: '-0.02em' }}
+              component={RouterLink}
+              to={roleHomePaths[role]}
+              variant="h3"
+              sx={{
+                color: 'common.white',
+                fontSize: { xs: '2rem', md: '2.7rem' },
+                fontWeight: 500,
+                letterSpacing: 0,
+                lineHeight: 1,
+              }}
             >
-              TicketPlatform
+              Greitas Darbelis
             </Typography>
 
             <Stack
               direction="row"
-              spacing={1}
+              spacing={{ xs: 1.5, md: 4 }}
               sx={{
                 alignItems: 'center',
                 flexWrap: 'wrap',
@@ -65,8 +86,6 @@ function AppShell() {
               }}
             >
               {navPages.map((page) => {
-                const isActive = page.path === activeNavPage?.path;
-
                 return (
                   <Button
                     key={page.path}
@@ -74,14 +93,15 @@ function AppShell() {
                     to={page.path}
                     disableElevation
                     sx={{
-                      px: 2.25,
+                      px: { xs: 1.5, md: 2 },
                       py: 1,
                       minWidth: 'auto',
-                      borderRadius: '12px',
+                      borderRadius: '8px',
                       color: 'common.white',
-                      backgroundColor: isActive ? 'primary.main' : 'transparent',
+                      fontSize: { xs: '1rem', md: '1.35rem' },
+                      backgroundColor: 'transparent',
                       '&:hover': {
-                        backgroundColor: isActive ? 'primary.main' : 'primary.dark',
+                        backgroundColor: 'primary.dark',
                       },
                     }}
                   >
@@ -90,53 +110,46 @@ function AppShell() {
                 );
               })}
 
-              <FormControl
-                size="small"
+              <IconButton
+                aria-label="Open role menu"
+                aria-controls={isRoleMenuOpen ? 'role-menu' : undefined}
+                aria-haspopup="menu"
+                aria-expanded={isRoleMenuOpen ? 'true' : undefined}
+                onClick={handleRoleMenuOpen}
                 sx={{
-                  minWidth: 164,
-                  '& .MuiOutlinedInput-root': {
-                    borderRadius: '999px',
-                    backgroundColor: 'secondary.main',
-                    color: 'common.white',
-                  },
-                  '& .MuiOutlinedInput-notchedOutline': {
-                    border: 'none',
-                  },
-                  '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
-                    border: 'none',
-                  },
-                  '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                    border: 'none',
-                  },
-                  '& .MuiSelect-icon': {
-                    color: 'common.white',
-                  },
-                  '& .MuiSelect-select': {
-                    py: 1,
-                    pr: 4.5,
-                    pl: 2,
-                    color: 'common.white',
-                  },
+                  width: { xs: 56, md: 78 },
+                  height: { xs: 56, md: 78 },
+                  borderRadius: '50%',
+                  bgcolor: 'primary.main',
+                  color: 'common.white',
+                  flex: '0 0 auto',
+                  '&:hover': { bgcolor: 'primary.dark' },
                 }}
               >
-              <Select
-                value={role}
-                onChange={(event) => handleRoleChange(event.target.value as UserRole)}
+                <PersonOutlineOutlined sx={{ fontSize: { xs: 30, md: 40 } }} />
+              </IconButton>
+              <Menu
+                id="role-menu"
+                anchorEl={roleMenuAnchor}
+                open={isRoleMenuOpen}
+                onClose={handleRoleMenuClose}
               >
                 {roles.map((availableRole) => (
-                  <MenuItem key={availableRole} value={availableRole}>
+                  <MenuItem
+                    key={availableRole}
+                    selected={availableRole === role}
+                    onClick={() => handleRoleChange(availableRole)}
+                  >
                     {roleLabels[availableRole]}
                   </MenuItem>
                 ))}
-              </Select>
-              </FormControl>
+              </Menu>
             </Stack>
           </Toolbar>
         </Container>
       </AppBar>
 
-      <Container maxWidth="xl" sx={{ py: { xs: 3, md: 4 } }}>
-        <AppBreadcrumbs />
+      <Container maxWidth={false} sx={{ px: { xs: 3, md: 8, lg: 12.5 }, py: { xs: 4, md: 7.5 } }}>
         <Outlet />
       </Container>
     </Box>

--- a/frontend/src/app/page-registry.ts
+++ b/frontend/src/app/page-registry.ts
@@ -4,6 +4,8 @@ import { EventDetailsPage } from '../features/events/EventDetailsPage';
 import CreateEventPage from '../features/events/CreateEventPage';
 import EditEventPage from '../features/events/EditEventPage';
 import { OrganizerEventsPage } from '../features/events/OrganizerEventsPage';
+import { MyEventsPage } from '../features/tickets/MyEventsPage';
+import { PurchasedTicketsPage } from '../features/tickets/PurchasedTicketsPage';
 import { roleHomePaths, type UserRole } from './roles';
 
 export type AppPage = {
@@ -23,13 +25,14 @@ export const appPages: AppPage[] = [
     path: '/customer',
     title: 'Customer',
     navLabel: 'Home',
+    showInNav: false,
   },
   {
     id: 'customer-events',
     role: 'customer',
     path: '/customer/events',
-    title: 'Events',
-    navLabel: 'Events',
+    title: 'Browse Events',
+    navLabel: 'Browse Events',
     component: EventListPage,
   },
   {
@@ -42,11 +45,21 @@ export const appPages: AppPage[] = [
     component: EventDetailsPage,
   },
   {
+    id: 'customer-my-events',
+    role: 'customer',
+    path: '/customer/my-events',
+    title: 'My Events',
+    navLabel: 'My Events',
+    component: MyEventsPage,
+  },
+  {
     id: 'customer-tickets',
     role: 'customer',
-    path: '/customer/tickets',
-    title: 'My Tickets',
-    navLabel: 'My Tickets',
+    path: '/customer/tickets/:eventId',
+    title: 'Your Tickets',
+    navLabel: 'Your Tickets',
+    showInNav: false,
+    component: PurchasedTicketsPage,
   },
   {
     id: 'organizer-overview',

--- a/frontend/src/features/tickets/MockQrCode.tsx
+++ b/frontend/src/features/tickets/MockQrCode.tsx
@@ -1,0 +1,94 @@
+import { Box } from '@mui/material';
+
+type MockQrCodeProps = {
+  value: string;
+};
+
+const QR_GRID_SIZE = 21;
+
+function isFinderPatternCell(x: number, y: number, originX: number, originY: number): boolean {
+  const relativeX = x - originX;
+  const relativeY = y - originY;
+
+  if (relativeX < 0 || relativeX > 6 || relativeY < 0 || relativeY > 6) {
+    return false;
+  }
+
+  const isOuterRing =
+    relativeX === 0 || relativeX === 6 || relativeY === 0 || relativeY === 6;
+  const isInnerSquare =
+    relativeX >= 2 && relativeX <= 4 && relativeY >= 2 && relativeY <= 4;
+
+  return isOuterRing || isInnerSquare;
+}
+
+function createSeed(value: string): number {
+  let hash = 2166136261;
+
+  for (const character of value) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function shouldFillCell(seed: number, x: number, y: number): boolean {
+  if (
+    isFinderPatternCell(x, y, 0, 0) ||
+    isFinderPatternCell(x, y, QR_GRID_SIZE - 7, 0) ||
+    isFinderPatternCell(x, y, 0, QR_GRID_SIZE - 7)
+  ) {
+    return true;
+  }
+
+  if (
+    (x <= 7 && y <= 7) ||
+    (x >= QR_GRID_SIZE - 8 && y <= 7) ||
+    (x <= 7 && y >= QR_GRID_SIZE - 8)
+  ) {
+    return false;
+  }
+
+  const mixedSeed = Math.imul(seed ^ Math.imul(x + 5, 374761393), (y + 11) * 668265263);
+
+  return ((mixedSeed >>> 0) & 3) !== 0;
+}
+
+export function MockQrCode({ value }: MockQrCodeProps) {
+  const seed = createSeed(value);
+  const cells = [];
+
+  for (let y = 0; y < QR_GRID_SIZE; y += 1) {
+    for (let x = 0; x < QR_GRID_SIZE; x += 1) {
+      if (shouldFillCell(seed, x, y)) {
+        cells.push(<rect key={`${x}-${y}`} x={x} y={y} width="1" height="1" fill="#000000" />);
+      }
+    }
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        p: 1.1,
+        border: '6px solid',
+        borderColor: 'primary.light',
+        borderRadius: '14px',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <svg
+        aria-label={`QR code for ticket ${value}`}
+        role="img"
+        viewBox={`0 0 ${QR_GRID_SIZE} ${QR_GRID_SIZE}`}
+        width="360"
+        height="360"
+        style={{ display: 'block', maxWidth: 'min(58vw, 360px)', height: 'auto' }}
+      >
+        <rect width={QR_GRID_SIZE} height={QR_GRID_SIZE} fill="#ffffff" />
+        {cells}
+      </svg>
+    </Box>
+  );
+}

--- a/frontend/src/features/tickets/MyEventsPage.tsx
+++ b/frontend/src/features/tickets/MyEventsPage.tsx
@@ -1,0 +1,167 @@
+import { useMemo } from 'react';
+import {
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  Stack,
+  Typography,
+} from '@mui/material';
+import CalendarMonthOutlined from '@mui/icons-material/CalendarMonthOutlined';
+import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
+import Grid from '@mui/material/Grid';
+import { Link as RouterLink } from 'react-router-dom';
+import type { AppPage } from '../../app/page-registry';
+import { getPurchasedEventsWithTickets, type MockPurchasedEvent } from './mockTicketDatabase';
+
+const myEventsPage: AppPage = {
+  id: 'customer-my-events',
+  role: 'customer',
+  path: '/customer/my-events',
+  title: 'My Events',
+  navLabel: 'My Events',
+};
+
+function formatEventDate(value: string): string {
+  const date = new Date(value);
+  const formattedDate = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+  const formattedTime = new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).format(date);
+
+  return `${formattedDate} • ${formattedTime}`;
+}
+
+function MyEventCard({ event }: { event: MockPurchasedEvent }) {
+  return (
+    <Card
+      elevation={0}
+      sx={{
+        overflow: 'hidden',
+        borderRadius: '14px',
+        boxShadow: '0 12px 28px rgba(6, 30, 35, 0.14)',
+      }}
+    >
+      <CardActionArea
+        component={RouterLink}
+        to={`/customer/tickets/${event.id}`}
+        sx={{
+          display: 'block',
+          color: 'inherit',
+          '&:hover .my-event-card-image': {
+            transform: 'scale(1.05)',
+          },
+        }}
+      >
+        <Box
+          className="my-event-card-image"
+          sx={{
+            height: { xs: 230, md: 360 },
+            backgroundImage: `url(${event.imageUrl})`,
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+            transition: 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          }}
+        />
+        <CardContent sx={{ p: { xs: 2.5, md: 3 } }}>
+          <Stack spacing={1.8}>
+            <Typography
+              variant="h5"
+              sx={{
+                fontSize: { xs: '1.45rem', md: '1.9rem' },
+                lineHeight: 1.2,
+                color: 'text.secondary',
+              }}
+            >
+              {event.title}
+            </Typography>
+
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <CalendarMonthOutlined sx={{ fontSize: 28, color: 'primary.dark' }} />
+              <Typography sx={{ fontSize: { xs: '1.05rem', md: '1.45rem' }, color: 'primary.dark' }}>
+                {formatEventDate(event.date)}
+              </Typography>
+            </Stack>
+
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <LocationOnOutlined sx={{ fontSize: 28, color: 'primary.dark' }} />
+              <Typography sx={{ fontSize: { xs: '1.05rem', md: '1.45rem' }, color: 'primary.dark' }}>
+                {event.location}
+              </Typography>
+            </Stack>
+          </Stack>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}
+
+export function MyEventsPage() {
+  const purchasedEvents = useMemo(() => getPurchasedEventsWithTickets(), []);
+  const now = useMemo(() => new Date(), []);
+  const upcomingEvents = purchasedEvents.filter((event) => new Date(event.date) >= now);
+  const pastEvents = purchasedEvents.filter((event) => new Date(event.date) < now);
+
+  return (
+    <Stack spacing={{ xs: 5, md: 7 }}>
+      <Typography
+        variant="h3"
+        sx={{ fontSize: { xs: '2.6rem', md: '3.5rem' }, lineHeight: 1.15, color: 'text.secondary' }}
+      >
+        {myEventsPage.title}
+      </Typography>
+
+      <Stack spacing={3}>
+        <Typography
+          variant="h4"
+          sx={{ fontSize: { xs: '2rem', md: '2.75rem' }, color: 'primary.dark' }}
+        >
+          Upcoming Events
+        </Typography>
+
+        {upcomingEvents.length > 0 ? (
+          <Grid container spacing={3}>
+            {upcomingEvents.map((event) => (
+              <Grid key={event.id} size={{ xs: 12, md: 6, lg: 4 }}>
+                <MyEventCard event={event} />
+              </Grid>
+            ))}
+          </Grid>
+        ) : (
+          <Typography sx={{ fontSize: { xs: '1.1rem', md: '1.45rem' }, color: 'primary.dark' }}>
+            No upcoming events
+          </Typography>
+        )}
+      </Stack>
+
+      <Stack spacing={3}>
+        <Typography
+          variant="h4"
+          sx={{ fontSize: { xs: '2rem', md: '2.75rem' }, color: 'primary.dark' }}
+        >
+          Past Events
+        </Typography>
+
+        {pastEvents.length > 0 ? (
+          <Grid container spacing={3}>
+            {pastEvents.map((event) => (
+              <Grid key={event.id} size={{ xs: 12, md: 6, lg: 4 }}>
+                <MyEventCard event={event} />
+              </Grid>
+            ))}
+          </Grid>
+        ) : (
+          <Typography sx={{ fontSize: { xs: '1.1rem', md: '1.45rem' }, color: 'primary.dark' }}>
+            No past events
+          </Typography>
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/frontend/src/features/tickets/PurchasedTicketsPage.tsx
+++ b/frontend/src/features/tickets/PurchasedTicketsPage.tsx
@@ -1,0 +1,122 @@
+import { useMemo } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ArrowBackRounded from '@mui/icons-material/ArrowBackRounded';
+import { Link as RouterLink, useParams } from 'react-router-dom';
+import type { AppPage } from '../../app/page-registry';
+import { MockQrCode } from './MockQrCode';
+import { getPurchasedTicketsForEvent } from './mockTicketDatabase';
+
+const purchasedTicketsPage: AppPage = {
+  id: 'customer-tickets',
+  role: 'customer',
+  path: '/customer/tickets/:eventId',
+  title: 'Your Tickets',
+  navLabel: 'Your Tickets',
+};
+
+function formatEventDate(value: string): string {
+  const date = new Date(value);
+  const formattedDate = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+  const formattedTime = new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).format(date);
+
+  return `${formattedDate} • ${formattedTime}`;
+}
+
+export function PurchasedTicketsPage() {
+  const { eventId } = useParams();
+  const purchasedTicketGroup = useMemo(() => getPurchasedTicketsForEvent(eventId), [eventId]);
+
+  return (
+    <Stack spacing={4}>
+      <Button
+        component={RouterLink}
+        to="/customer/my-events"
+        startIcon={<ArrowBackRounded />}
+        variant="outlined"
+        sx={{
+          alignSelf: 'flex-start',
+          borderRadius: '8px',
+          bgcolor: 'background.paper',
+          color: 'text.secondary',
+          px: 3,
+          py: 1.3,
+        }}
+      >
+        Go Back
+      </Button>
+
+      <Typography
+        variant="h3"
+        sx={{ fontSize: { xs: '2.5rem', md: '3.45rem' }, lineHeight: 1.15, color: 'text.secondary' }}
+      >
+        {purchasedTicketsPage.title}
+      </Typography>
+
+      {!purchasedTicketGroup ? (
+        <Alert severity="info" sx={{ maxWidth: 720 }}>
+          No purchased tickets were found for this event.
+        </Alert>
+      ) : null}
+
+      <Stack spacing={4}>
+        {purchasedTicketGroup?.tickets.map((ticket) => (
+          <Card
+            key={ticket.id}
+            elevation={0}
+            sx={{
+              overflow: 'hidden',
+              borderRadius: '14px',
+              boxShadow: '0 18px 38px rgba(6, 30, 35, 0.12)',
+            }}
+          >
+            <Box sx={{ bgcolor: 'primary.main', color: 'common.white', p: { xs: 3, md: 4.5 } }}>
+              <Typography
+                variant="h4"
+                sx={{ fontSize: { xs: '2rem', md: '2.65rem' }, mb: 2, color: 'common.white' }}
+              >
+                {purchasedTicketGroup.event.title}
+              </Typography>
+              <Typography sx={{ fontSize: { xs: '1.25rem', md: '1.7rem' }, color: 'common.white' }}>
+                {formatEventDate(purchasedTicketGroup.event.date)}
+              </Typography>
+              <Typography sx={{ fontSize: { xs: '1.25rem', md: '1.7rem' }, color: 'common.white' }}>
+                {purchasedTicketGroup.event.location}
+              </Typography>
+            </Box>
+
+            <CardContent sx={{ p: { xs: 4, md: 7 }, textAlign: 'center' }}>
+              <Stack spacing={4} sx={{ alignItems: 'center' }}>
+                <MockQrCode value={ticket.ticketNumber} />
+                <Typography
+                  sx={{
+                    color: 'primary.dark',
+                    fontSize: { xs: '1.45rem', md: '2rem' },
+                    letterSpacing: '0.08em',
+                  }}
+                >
+                  {ticket.ticketNumber}
+                </Typography>
+              </Stack>
+            </CardContent>
+          </Card>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}

--- a/frontend/src/features/tickets/mockTicketDatabase.ts
+++ b/frontend/src/features/tickets/mockTicketDatabase.ts
@@ -1,0 +1,128 @@
+export type MockPurchasedEvent = {
+  id: string;
+  title: string;
+  date: string;
+  location: string;
+  imageUrl: string;
+};
+
+export type MockPurchasedTicket = {
+  id: string;
+  ticketNumber: string;
+  eventId: string;
+};
+
+type MockTicketDatabase = {
+  events: MockPurchasedEvent[];
+  tickets: MockPurchasedTicket[];
+};
+
+const STORAGE_KEY = 'ticket-platform.mock-purchased-tickets';
+
+const initialDatabase: MockTicketDatabase = {
+  events: [
+    {
+      id: 'summer-music-festival-2026',
+      title: 'Summer Music Festival 2026',
+      date: '2026-06-15T18:00:00',
+      location: 'Central Park, New York',
+      imageUrl:
+        'https://images.unsplash.com/photo-1672841821756-fc04525771c2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb25jZXJ0JTIwbXVzaWMlMjBmZXN0aXZhbHxlbnwxfHx8fDE3NzY0MjAyMjV8MA&ixlib=rb-4.1.0&q=80&w=1080',
+    },
+  ],
+  tickets: [
+    {
+      id: 'ticket-1',
+      ticketNumber: 'TKT-BIHTMTWIP',
+      eventId: 'summer-music-festival-2026',
+    },
+    {
+      id: 'ticket-2',
+      ticketNumber: 'TKT-QZ7N42KPA',
+      eventId: 'summer-music-festival-2026',
+    },
+  ],
+};
+
+function isMockTicketDatabase(value: unknown): value is MockTicketDatabase {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<MockTicketDatabase>;
+
+  return Array.isArray(candidate.events) && Array.isArray(candidate.tickets);
+}
+
+function normalizeMockTicketDatabase(database: MockTicketDatabase): MockTicketDatabase {
+  const events = database.events.map((event) => {
+    const fallbackEvent = initialDatabase.events.find((candidateEvent) => candidateEvent.id === event.id);
+
+    return {
+      ...event,
+      imageUrl: event.imageUrl ?? fallbackEvent?.imageUrl ?? '',
+    };
+  });
+
+  return { ...database, events };
+}
+
+export function getMockTicketDatabase(): MockTicketDatabase {
+  const storedValue = window.localStorage.getItem(STORAGE_KEY);
+
+  if (storedValue) {
+    try {
+      const parsedValue = JSON.parse(storedValue) as unknown;
+
+      if (isMockTicketDatabase(parsedValue)) {
+        const normalizedDatabase = normalizeMockTicketDatabase(parsedValue);
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalizedDatabase));
+
+        return normalizedDatabase;
+      }
+    } catch {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(initialDatabase));
+
+  return initialDatabase;
+}
+
+export function getPurchasedTicketsWithEvents() {
+  const database = getMockTicketDatabase();
+
+  return database.tickets.flatMap((ticket) => {
+    const event = database.events.find((candidateEvent) => candidateEvent.id === ticket.eventId);
+
+    return event ? [{ ...ticket, event }] : [];
+  });
+}
+
+export function getPurchasedEventsWithTickets() {
+  const database = getMockTicketDatabase();
+
+  return database.events.flatMap((event) => {
+    const tickets = database.tickets.filter((ticket) => ticket.eventId === event.id);
+
+    return tickets.length > 0 ? [{ ...event, tickets }] : [];
+  });
+}
+
+export function getPurchasedTicketsForEvent(eventId: string | undefined) {
+  if (!eventId) {
+    return null;
+  }
+
+  const database = getMockTicketDatabase();
+  const event = database.events.find((candidateEvent) => candidateEvent.id === eventId);
+
+  if (!event) {
+    return null;
+  }
+
+  const tickets = database.tickets.filter((ticket) => ticket.eventId === event.id);
+
+  return tickets.length > 0 ? { event, tickets } : null;
+}


### PR DESCRIPTION
## Summary

Implements SCRUM-29: customer can view purchased tickets after payment.

The customer flow now follows the Figma prototype:
- Customer opens `My Events`.
- The page shows events for which the customer has purchased tickets.
- Clicking a purchased event opens the ticket/QR page for that event.
- Purchased tickets are displayed separately with event information, a unique ticket number, and a QR code.

## Prototype Alignment

- Customer top navigation shows `Browse Events` and `My Events`.
- `My Events` displays purchased-event cards with image, date, title, and location.
- Clicking the event opens the `Your Tickets` screen.
- `Your Tickets` includes a back button, event details, ticket QR code, and ticket number.
- The profile icon in the header is centered and styled as a circular menu button.

## Mock Data

Added a local mock ticket database using `localStorage` so the flow can be tested without backend data.

Included mock event:
- Summer Music Festival 2026
- Jun 15, 2026 • 18:00
- Central Park, New York

Included mock tickets:
- TKT-BIHTMTWIP
- TKT-QZ7N42KPA

## Testing

- Ran `npm run build`.
- Manually smoke-tested the customer flow in browser:
  - `/customer/my-events`
  - Click purchased event card
  - Verify `/customer/tickets/summer-music-festival-2026`
  - Verify event info, QR codes, ticket numbers, and back navigation
